### PR TITLE
Fix Advent Calendar links

### DIFF
--- a/articles/connect-cloud9-via-remote-ssh.md
+++ b/articles/connect-cloud9-via-remote-ssh.md
@@ -10,7 +10,7 @@ published: true
 この記事は
 [みすてむず いず みすきーしすてむず (3) Advent Calendar 2023](https://adventar.org/calendars/8615)[^1]
 および
-[AWS（Amazon Web Services） Advent Calendar 2023 シリーズ2](https://qiita.com/advent-calendar/2023/aws2)
+[AWS（Amazon Web Services） Advent Calendar 2023 シリーズ2](https://qiita.com/advent-calendar/2023/aws)
 の15日目です。
 :::
 

--- a/articles/connect-cloud9-via-remote-ssh.md
+++ b/articles/connect-cloud9-via-remote-ssh.md
@@ -10,7 +10,7 @@ published: true
 この記事は
 [みすてむず いず みすきーしすてむず (3) Advent Calendar 2023](https://adventar.org/calendars/8615)[^1]
 および
-[AWS（Amazon Web Services） Advent Calendar 2023 シリーズ2](https://qiita.com/advent-calendar/2020/aws2)
+[AWS（Amazon Web Services） Advent Calendar 2023 シリーズ2](https://qiita.com/advent-calendar/2023/aws2)
 の15日目です。
 :::
 

--- a/articles/f5cbfda1388d6d.md
+++ b/articles/f5cbfda1388d6d.md
@@ -10,7 +10,7 @@ published: true
 この記事は
 [みすてむず いず みすきーしすてむず (3) Advent Calendar 2023](https://adventar.org/calendars/8615)[^1]
 および
-[AWS（Amazon Web Services） Advent Calendar 2023](https://qiita.com/advent-calendar/2023/aws2)
+[AWS（Amazon Web Services） Advent Calendar 2023](https://qiita.com/advent-calendar/2023/aws)
 の4日目です。
 :::
 

--- a/articles/f5cbfda1388d6d.md
+++ b/articles/f5cbfda1388d6d.md
@@ -10,7 +10,7 @@ published: true
 この記事は
 [みすてむず いず みすきーしすてむず (3) Advent Calendar 2023](https://adventar.org/calendars/8615)[^1]
 および
-[AWS（Amazon Web Services） Advent Calendar 2023](https://qiita.com/advent-calendar/2020/aws2)
+[AWS（Amazon Web Services） Advent Calendar 2023](https://qiita.com/advent-calendar/2023/aws2)
 の4日目です。
 :::
 


### PR DESCRIPTION
## Summary
- correct Advent Calendar links referencing 2020 to 2023

## Testing
- `npx textlint articles/f5cbfda1388d6d.md articles/connect-cloud9-via-remote-ssh.md`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68416a267114832e81fb1a69be9de51d