### PR TITLE
[codex] add agent instructions for Zenn

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,24 +1,27 @@
 # Zenn コンテンツ用リポジトリ — AI エージェント向けガイド
 
-このリポジトリは Zenn 記事/本の原稿管理用です。エージェントは以下の流れ・規約に従って作業してください。一般論ではなく、このリポジトリ固有のパターンをまとめています。
+このリポジトリはZenn記事/本の原稿管理用です。エージェントは以下の流れ・規約に従って作業してください。一般論ではなく、このリポジトリ固有のパターンをまとめています。
 
 ## 構成と役割
-- `articles/`: 記事の Markdown 原稿を配置。ファイル名はスラッグ（例: `cdktf-for-usual-terraform-users.md`）。
+- `articles/`: 記事のMarkdown原稿を配置。ファイル名はスラッグ（例: `cdktf-for-usual-terraform-users.md`）。
 - `images/<slug>/`: 記事ごとの画像ディレクトリ。記事からは `/images/<slug>/...` で参照。
-- `books/`: Zenn 本の原稿（未使用の場合あり）。
+- `books/`: Zenn本の原稿（未使用の場合あり）。
 - `.textlintrc`: 日本語向け校正設定（`prh`, `preset-ja-*`, `spellcheck-tech-word`）。
 - `.github/workflows/rules/WEB+DB_PRESS.yml`: `prh` で参照する用字用語ルール集。
-- `package.json`: `zenn-cli` と `textlint` 関連パッケージを管理（npm scripts は最小）。
+- `.github/workflows/textlint.yml`: PR時に`textlint`を`reviewdog`で実行するCI。
+- `mise.toml`: `Node.js`/`pnpm`のバージョン管理。
+- `package.json`: `zenn-cli` と `textlint` 関連パッケージを管理（npm scriptsは最小）。
 
 ## 典型ワークフロー
 - 新規ブランチ: 命名は任意（例: `add/20251204_advent_calendar` など）。
-- 記事作成: `npx zenn new:article --title "タイトル" --slug "my-article" --type tech`
+- `Node.js`/`pnpm`は`mise.toml`の指定を前提とし、必要に応じて`mise install`を実行。
+- 記事作成: `pnpm exec zenn new:article --title "タイトル" --slug "my-article" --type tech`
 - 画像配置: `mkdir -p images/my-article` に画像を保存し、本文から `/images/my-article/xxx.png` で参照。
-- ローカルプレビュー: `npx zenn preview` を実行し `http://localhost:8000` を確認。
-- 校正（lint）: `npx textlint -f stylish "articles/**/*.md"`／自動修正は `--fix` を付与。
-- レビュー後、`main` へ PR。公開は Zenn 側の同期に従う。
+- ローカルプレビュー: `pnpm exec zenn preview` または `pnpm run preview` を実行し `http://localhost:8000` を確認。
+- 校正（lint）: `pnpm exec textlint -f stylish "articles/**/*.md"` または `pnpm run lint`／自動修正は `--fix` を付与。
+- レビュー後、`main` へPR。公開はZenn側の同期に従う。
 
-## フロントマター規約（実例に基づく）
+## フロントマター規約（実例ベース）
 - 基本例（`articles/cdktf-for-usual-terraform-users.md` ほか）
   ```md
   ---
@@ -31,7 +34,7 @@
   # published_at: 2025-12-04 07:00
   ---
   ```
-- 予約公開する記事は `published: true` と共に `published_at` を設定（未設定なら即時公開）。
+- 予約公開する記事は `published: true` とともに `published_at` を設定（未設定なら即時公開）。
 - 下書きは `published: false` を使用。
 
 ## 画像と参照パターン
@@ -40,39 +43,46 @@
 - 相対ではなくルート起点（`/images/...`）で参照するのが既存記事の実例。
 
 ## ライティングスタイル
-- 既存記事の文体・構成・思考過程を踏襲して作成（例: `articles/connect-cloud9-via-remote-ssh.md`, `articles/introduction_of_mise.md`, `articles/cdktf-for-usual-terraform-users.md`）。
-- 構成の基本: 「はじめに」で背景と狙い→用語・前提→手順→ハマりどころ/補足→まとめ。
+- 既存記事の文体・構成・思考過程を踏襲して作成。
+- 例: `articles/connect-cloud9-via-remote-ssh.md`
+- 例: `articles/introduction_of_mise.md`
+- 例: `articles/cdktf-for-usual-terraform-users.md`
+- 構成の基本:「はじめに」で背景と狙い→用語・前提→手順→ハマりどころ/補足→まとめ。
 - アドベントカレンダー等は`:::message`ブロックで明示し、必要に応じて`@[card](URL)`を利用。
 - 参考情報や補足には脚注（`[^1]`）を活用し、末尾に脚注本文を配置。
 - コードやコマンドはフェンス付きコードブロック＋言語指定（`bash`, `ts`, `toml` 等）。
 - コマンド例は原則macOS + fish前提。heredocは避け、`printf`/`echo`で代替。
+- JavaScript系のローカル実行は`npx`より`pnpm exec`を優先し、依存関係を変更するときは`npm`実行で`package-lock.json`を不用意に更新しない。
 - 用字用語は`.textlintrc`と`WEB+DB_PRESS.yml`に準拠。lint指摘を尊重して修正。
   - ただし、従った結果日本語として不自然な表現になるときは従わないものとする。
 
 ## 校正（textlint）
 - 設定ファイル: `.textlintrc`。`prh` のルールは `.github/workflows/rules/WEB+DB_PRESS.yml` を参照。
 - 実行例:
-  - 全体: `npx textlint -f stylish "articles/**/*.md"`
-  - 1ファイル: `npx textlint -f stylish articles/<slug>.md`
-  - 自動修正: `npx textlint --fix "articles/**/*.md"`
+  - 全体: `pnpm exec textlint -f stylish "articles/**/*.md"` または `pnpm run lint`
+  - 1ファイル: `pnpm exec textlint -f stylish articles/<slug>.md`
+  - 自動修正: `pnpm exec textlint --fix "articles/**/*.md"` または `pnpm run lint:fix`
+- PRでは`.github/workflows/textlint.yml`により`textlint`が走るため、PR作成前に対象ファイルlintを通しておく。
 - 注意: ルールファイルのパスを変更する場合は `.textlintrc` の `rulePaths` も更新が必要。
 
 ## Zenn CLI の利用
-- 依存関係は `package.json` に定義済み（`zenn-cli`）。`npx zenn ...` でローカル実行。
+- 依存関係は `package.json` に定義済み（`zenn-cli`）。`pnpm exec zenn ...` でローカル実行。
 - よく使うコマンド:
-  - 新規記事: `npx zenn new:article --title "..." --slug "..." --type tech`
-  - プレビュー: `npx zenn preview`
+  - 新規記事: `pnpm exec zenn new:article --title "..." --slug "..." --type tech`
+  - プレビュー: `pnpm exec zenn preview` または `pnpm run preview`
 
 ### npm scripts（任意）
-- `npm run preview`: `zenn preview`
-- `npm run lint`: `textlint -f stylish "articles/**/*.md"`
-- `npm run lint:fix`: `textlint --fix "articles/**/*.md"`
+- `pnpm run preview`: `zenn preview`
+- `pnpm run lint`: `textlint -f stylish "articles/**/*.md"`
+- `pnpm run lint:fix`: `textlint --fix "articles/**/*.md"`
 
 ## リポジトリの前提・補足
-- 既存 README は最小。運用上のコマンドは本ファイルの記載を参照。
-- 文章スタイルは日本語の用字用語ルール（WEB+DB PRESS ベース）に準拠する設定。lint 結果を尊重。
+- 既存READMEは最小。運用上のコマンドは本ファイルの記載を参照。
+- 文章スタイルは日本語の用字用語ルールに準拠する設定。lint結果を尊重。
 - 例示ファイル: `articles/cdktf-for-usual-terraform-users.md`（画像参照やフロントマターの好例）。
--.macOS + fish を前提にコマンド例を記述（heredoc 非推奨）。
+- macOS + fishを前提にコマンド例を記述（heredoc非推奨）。
 
 ---
-不明点や追加したい運用（例: 固定の npm scripts、CI での textlint 実行、画像最適化方針など）があればお知らせください。実運用に合わせて本ガイドを拡張します。
+不明点や追加したい運用があればお知らせください。
+例: 固定のnpm scripts、CIでのtextlint実行、画像の最適化方針など。
+実運用に合わせて本ガイドを拡張します。

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,6 +11,7 @@
 - `.github/workflows/textlint.yml`: PR時に`textlint`を`reviewdog`で実行するCI。
 - `mise.toml`: `Node.js`/`pnpm`のバージョン管理。
 - `package.json`: `zenn-cli` と `textlint` 関連パッケージを管理（npm scriptsは最小）。
+- `AGENTS.md`: Codex向けの同等ガイド。内容を更新する場合は、必要に応じてこちらとの整合性も保つ。
 
 ## 典型ワークフロー
 - 新規ブランチ: 命名は任意（例: `add/20251204_advent_calendar` など）。
@@ -52,7 +53,7 @@
 - 参考情報や補足には脚注（`[^1]`）を活用し、末尾に脚注本文を配置。
 - コードやコマンドはフェンス付きコードブロック＋言語指定（`bash`, `ts`, `toml` 等）。
 - コマンド例は原則macOS + fish前提。heredocは避け、`printf`/`echo`で代替。
-- JavaScript系のローカル実行は`npx`より`pnpm exec`を優先し、依存関係を変更するときは`npm`実行で`package-lock.json`を不用意に更新しない。
+- JavaScript系のローカル実行は`npx`より`pnpm exec`を優先し、依存関係を変更するときは`npm`実行で不要な`package-lock.json`を生成しない。
 - 用字用語は`.textlintrc`と`WEB+DB_PRESS.yml`に準拠。lint指摘を尊重して修正。
   - ただし、従った結果日本語として不自然な表現になるときは従わないものとする。
 
@@ -62,7 +63,8 @@
   - 全体: `pnpm exec textlint -f stylish "articles/**/*.md"` または `pnpm run lint`
   - 1ファイル: `pnpm exec textlint -f stylish articles/<slug>.md`
   - 自動修正: `pnpm exec textlint --fix "articles/**/*.md"` または `pnpm run lint:fix`
-- PRでは`.github/workflows/textlint.yml`により`textlint`が走るため、PR作成前に対象ファイルlintを通しておく。
+- 記事PRでは`.github/workflows/textlint.yml`により`articles/`配下へ`textlint`が走るため、PR作成前に対象記事のlintを通しておく。
+- 記事以外のMarkdownを編集した場合も、可能なら対象ファイルへ個別に`textlint`を実行する。
 - 注意: ルールファイルのパスを変更する場合は `.textlintrc` の `rulePaths` も更新が必要。
 
 ## Zenn CLI の利用

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md
+# Zenn コンテンツ用リポジトリ — AI エージェント向けガイド (Codex)
 
 このリポジトリはZenn記事・本の原稿を管理するためのものです。Codexは以下の方針に従って作業してください。
 
@@ -22,16 +22,16 @@
 - `:::message` や `:::message alert` は意味がある限り維持する。
 - コマンド例はmacOSとfishを前提にする。
 - fish前提のため、複数行の入力例では`heredoc`を避け、必要に応じて`printf`や`echo`で代替する。
-- JavaScript系のローカル実行は `npx` より `pnpm exec` を優先する。
+- JavaScript系のローカル実行は`npx`より`pnpm exec`を優先する。
 - `Node.js`/`pnpm`は`mise.toml`の指定を前提にし、必要に応じて`mise install`を案内する。
-- 依存関係を変更する場合は`pnpm`を使い、`npm`実行により`package-lock.json`を不用意に更新しない。
+- 依存関係を変更する場合は`pnpm`を使い、`npm`実行により不要な`package-lock.json`を生成しない。
 
 ## 記事の書き方
 
 - 基本構成は「はじめに」→前提・背景→手順→補足やハマりどころ→まとめ。
-- 参考情報や補足は必要に応じて脚注 `[^1]` を使う。
+- 参考情報や補足は必要に応じて脚注`[^1]`を使う。
 - コマンドやコードはフェンス付きコードブロックを使い、言語名を付ける。
-- 画像は `images/<slug>/` に置き、本文では `/images/<slug>/file.png` の形式で参照する。
+- 画像は`images/<slug>/`に置き、本文では`/images/<slug>/file.png`の形式で参照する。
 - 相対パスで画像参照を書かない。
 
 ## フロントマター
@@ -73,5 +73,6 @@ published: true
 ## 検証
 
 - Markdownを編集したら、可能なら対象ファイルに対して `pnpm exec textlint -f stylish ...` を実行して確認する。
-- PRでは`.github/workflows/textlint.yml`により`textlint`が走るため、PR作成前に対象ファイルlintを通しておく。
+- 記事PRでは`.github/workflows/textlint.yml`により`articles/`配下へ`textlint`が走るため、PR作成前に対象記事のlintを通しておく。
+- 記事以外のMarkdownを編集した場合も、可能なら対象ファイルへ個別に`textlint`を実行する。
 - 記事全体に影響する変更をした場合のみ、必要に応じて全体lintやプレビューを行う。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# AGENTS.md
+
+このリポジトリはZenn記事・本の原稿を管理するためのものです。Codexは以下の方針に従って作業してください。
+
+## リポジトリ構成
+
+- `articles/`: Zenn記事のMarkdown原稿。
+- `images/<slug>/`: 記事ごとの画像置き場。本文からは `/images/<slug>/...` で参照する。
+- `books/`: Zenn本の原稿。
+- `.textlintrc`: 日本語校正の設定。
+- `.github/workflows/rules/WEB+DB_PRESS.yml`: `prh` 用の用字用語ルール。
+- `.github/workflows/textlint.yml`: PR時に`textlint`を`reviewdog`で実行するCI。
+- `mise.toml`: `Node.js`/`pnpm`のバージョン管理。
+- `package.json`: `Zenn CLI`と`textlint`の依存関係・`npm scripts`。
+- `.github/copilot-instructions.md`: Copilot向けの同等ガイド。内容を更新する場合は、必要に応じてこちらとの整合性も保つ。
+
+## 基本方針
+
+- このリポジトリではコードよりもMarkdown原稿の編集が主目的。
+- 既存記事の文体・構成に寄せて編集する。
+- 変更は依頼範囲に限定し、無関係な表現調整は広げない。
+- `:::message` や `:::message alert` は意味がある限り維持する。
+- コマンド例はmacOSとfishを前提にする。
+- fish前提のため、複数行の入力例では`heredoc`を避け、必要に応じて`printf`や`echo`で代替する。
+- JavaScript系のローカル実行は `npx` より `pnpm exec` を優先する。
+- `Node.js`/`pnpm`は`mise.toml`の指定を前提にし、必要に応じて`mise install`を案内する。
+- 依存関係を変更する場合は`pnpm`を使い、`npm`実行により`package-lock.json`を不用意に更新しない。
+
+## 記事の書き方
+
+- 基本構成は「はじめに」→前提・背景→手順→補足やハマりどころ→まとめ。
+- 参考情報や補足は必要に応じて脚注 `[^1]` を使う。
+- コマンドやコードはフェンス付きコードブロックを使い、言語名を付ける。
+- 画像は `images/<slug>/` に置き、本文では `/images/<slug>/file.png` の形式で参照する。
+- 相対パスで画像参照を書かない。
+
+## フロントマター
+
+既存記事に合わせ、最低限次の形式を基準にする。
+
+```md
+---
+title: "タイトル"
+emoji: "🧐"
+type: "tech" # tech / idea
+topics: ["aws", "terraform"]
+published: true
+# 予約公開する場合のみ
+# published_at: 2025-12-04 07:00
+---
+```
+
+- 下書きは `published: false`。
+- 予約公開する場合は `published: true` と `published_at` を併用する。
+
+## 典型作業
+
+- 新規記事作成: `pnpm exec zenn new:article --title "タイトル" --slug "my-article" --type tech`
+- プレビュー: `pnpm exec zenn preview`
+- npm scriptでのプレビュー: `pnpm run preview`
+- 1ファイルlint: `pnpm exec textlint -f stylish articles/<slug>.md`
+- 全体lint: `pnpm exec textlint -f stylish "articles/**/*.md"`
+- 自動修正: `pnpm exec textlint --fix "articles/**/*.md"`
+- npm scriptでのlint: `pnpm run lint` / `pnpm run lint:fix`
+
+## 編集時の注意
+
+- textlintの指摘は尊重するが、不自然な日本語になるなら機械的に従わない。
+- 既存の用語・表記ゆれは周辺記事に合わせる。
+- 画像追加が必要なら、記事スラッグと同名のディレクトリを `images/` 配下に作る。
+- 既存のfrontmatterや公開設定は、依頼がない限り変更しない。
+
+## 検証
+
+- Markdownを編集したら、可能なら対象ファイルに対して `pnpm exec textlint -f stylish ...` を実行して確認する。
+- PRでは`.github/workflows/textlint.yml`により`textlint`が走るため、PR作成前に対象ファイルlintを通しておく。
+- 記事全体に影響する変更をした場合のみ、必要に応じて全体lintやプレビューを行う。


### PR DESCRIPTION
## Summary
- Add AGENTS.md with Zenn-specific editing, frontmatter, image, pnpm, mise, and validation guidance for Codex.
- Align the Copilot instruction file with the pnpm/mise workflow and PR-time textlint guidance.
- Clean up the Copilot guide so it passes the repository textlint rules.

## Validation
- `pnpm exec textlint -f stylish AGENTS.md .github/copilot-instructions.md`
- `git diff --check`

## Notes
- `.serena/` was generated locally by tooling and intentionally left out of this PR.